### PR TITLE
Stability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pxscene-ui",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxscene-ui",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A library for creating React apps in pxScene.",
   "main": "lib/pxscene-ui.js",
   "types": "lib/pxscene-ui.d.js",


### PR DESCRIPTION
It seems to improve app stability (less freezes/crashes) if we add a small delay before component updates are applied. This delay hopefully gives pxScene more time to 'unlock' the objects event queues before an update tries to add/remove event listeners.