### PR TITLE
Fixes non-blocking nature of SCENE.onClose

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pxscene-ui",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxscene-ui",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A library for creating React apps in pxScene.",
   "main": "lib/pxscene-ui.js",
   "types": "lib/pxscene-ui.d.js",


### PR DESCRIPTION
There was a bug with the _SCENE.onClose_ handler which resulted in _componentWillUnmount()_ being called for only *some* of the components in the tree. This was due to the fact that _deleteElement()_ was an asynchronous function.

This pull request converts _deleteElement()_ into a synchronous function while preserving all other behavior. As a result, Spark should now correctly block on _SCENE.onClose_ and wait for *all* components to be deleted (and their respective _componentWillUnmount()_ to be called).